### PR TITLE
ioutil.Discard default writer for stdout/err

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ func main() {
 }
 ```
 
+Note: `StdoutWriter` and `StderrWriter` is set to the `ioutil.Discard` writer by default.
+
 Now run it:
 
 ```

--- a/exec_streamer_builder.go
+++ b/exec_streamer_builder.go
@@ -3,6 +3,7 @@ package execstreamer
 import (
 	"errors"
 	"io"
+	"io/ioutil"
 )
 
 //NewExecStreamerBuilder will create a builder to elegantly create a new ExecStreamer
@@ -127,10 +128,10 @@ func (e *execStreamerBuilder) Build() (ExecStreamer, error) {
 		return nil, errors.New("ExecStreamerBuilder requires Exe to be non-empty")
 	}
 	if e.d.StdoutWriter == nil {
-		return nil, errors.New("ExecStreamerBuilder requires StdoutWriter to be set")
+		e.d.StdoutWriter = ioutil.Discard
 	}
 	if e.d.StderrWriter == nil {
-		return nil, errors.New("ExecStreamerBuilder requires StderrWriter to be set")
+		e.d.StderrWriter = ioutil.Discard
 	}
 
 	return e.d, nil


### PR DESCRIPTION
We should provide a usable default here. With interface types, one good way is to pass something that provides a no-op implementation of the interface. And it turns out that the stdlib ioutil package comes with a no-op io.Writer, called ioutil.Discard. This is just an application of the Go idiom "make the zero value useful".